### PR TITLE
Allow shadowban-threshold to be disabled

### DIFF
--- a/config.ini.sample
+++ b/config.ini.sample
@@ -10,7 +10,7 @@
 
 #accounts-file:         # Load accounts from CSV file containing "auth_service,username,passwd" lines.
 #level: 30              # Minimum trainer level required. Lower levels will yield an error.
-#shadowban-threshold: 3 # Mark an account as shadowbanned after this many errors.
+#shadowban-threshold: 3 # Mark an account as shadowbanned after this many errors. (use 0 to disable threshold)
                         # If allPGPool is specified the account gets swapped out.
 
 

--- a/pgscout/Scout.py
+++ b/pgscout/Scout.py
@@ -78,9 +78,12 @@ class Scout(POGOAccount):
                     else:
                         job.result = self.scout_error("Could not determine encounter_id for {} at {}, {}".format(job.pokemon_name, job.lat, job.lng))
 
-                # Check shadowban status
-                if self.shadowbanned or ((self.errors >= cfg_get('shadowban_threshold')) and (cfg_get('shadowban_threshold') !=0)) :
+                # Mark shadowbanned if too many errors
+                sb_threshold = cfg_get('shadowban_threshold')
+                if sb_threshold and self.errors >= sb_threshold:
                     self.shadowbanned = True
+
+                if self.shadowbanned:
                     self.log_warning("Account probably shadowbanned. Stopping.")
                     break
 

--- a/pgscout/Scout.py
+++ b/pgscout/Scout.py
@@ -79,7 +79,7 @@ class Scout(POGOAccount):
                         job.result = self.scout_error("Could not determine encounter_id for {} at {}, {}".format(job.pokemon_name, job.lat, job.lng))
 
                 # Check shadowban status
-                if self.shadowbanned or self.errors >= cfg_get('shadowban_threshold'):
+                if self.shadowbanned or ((self.errors >= cfg_get('shadowban_threshold')) and (cfg_get('shadowban_threshold') !=0)) :
                     self.shadowbanned = True
                     self.log_warning("Account probably shadowbanned. Stopping.")
                     break


### PR DESCRIPTION
This allows the use of 0 to disable shadowban-threshold and allow PGScout to run without stopping due to errors.  I am seeing random errors as a matter of course and there is no mechanism to reset the error count.  Eventually all accounts get turned off for shadowbans but they are not actually shadowbanned