### PR TITLE
Add blacklist feature

### DIFF
--- a/pgscout.py
+++ b/pgscout.py
@@ -45,7 +45,7 @@ def get_iv():
     pokemon_id = request.args["pokemon_id"]
     pokemon_name = get_pokemon_name(pokemon_id)
 
-    force = request.args.get["force", 0]
+    force = request.args.get("force", 0)
     if (force == 0):
         if (any(poke[0] == int(pokemon_id) for poke in blacklist)):
             odds = int(blacklist[[x[0] for x in blacklist].index(int(pokemon_id))][1])

--- a/pgscout.py
+++ b/pgscout.py
@@ -72,7 +72,7 @@ def get_iv():
         return jsonify(result)
 
     # Create a ScoutJob
-    job = ScoutJob(pokemon_id, encounter_id, spawn_point_id, lat, lng, force)
+    job = ScoutJob(pokemon_id, encounter_id, spawn_point_id, lat, lng)
 
     # Enqueue and wait for job to be processed
     jobs.put(job)

--- a/pgscout.py
+++ b/pgscout.py
@@ -45,15 +45,17 @@ def get_iv():
     pokemon_id = request.args["pokemon_id"]
     pokemon_name = get_pokemon_name(pokemon_id)
 
-    if (any(poke[0] == int(pokemon_id) for poke in blacklist)):
-        odds = int(blacklist[[x[0] for x in blacklist].index(int(pokemon_id))][1])
-        if (randint (1,100) <= odds):
-            errorstr = "Ignoring {} (ignore rate {})".format(pokemon_name, odds)
-            log.info(errorstr)
-            return jsonify({
-                'success': False,
-                'error': errorstr
-            })
+    force = request.args.get["force", 0]
+    if (force == 0):
+        if (any(poke[0] == int(pokemon_id) for poke in blacklist)):
+            odds = int(blacklist[[x[0] for x in blacklist].index(int(pokemon_id))][1])
+            if (randint (1,100) <= odds):
+                errorstr = "Ignoring {} (ignore rate {})".format(pokemon_name, odds)
+                log.info(errorstr)
+                return jsonify({
+                    'success': False,
+                    'error': errorstr
+                })
     lat = request.args["latitude"]
     lng = request.args["longitude"]
 
@@ -70,7 +72,7 @@ def get_iv():
         return jsonify(result)
 
     # Create a ScoutJob
-    job = ScoutJob(pokemon_id, encounter_id, spawn_point_id, lat, lng)
+    job = ScoutJob(pokemon_id, encounter_id, spawn_point_id, lat, lng, force)
 
     # Enqueue and wait for job to be processed
     jobs.put(job)

--- a/pgscout.py
+++ b/pgscout.py
@@ -46,7 +46,7 @@ def get_iv():
     pokemon_name = get_pokemon_name(pokemon_id)
 
     force = request.args.get("force", 0)
-    if (force == 0):
+    if (int(force) != 1):
         if (any(poke[0] == int(pokemon_id) for poke in blacklist)):
             odds = int(blacklist[[x[0] for x in blacklist].index(int(pokemon_id))][1])
             if (randint (1,100) <= odds):

--- a/pgscout/Scout.py
+++ b/pgscout/Scout.py
@@ -64,7 +64,7 @@ class Scout(POGOAccount):
             if (any(poke[0] == job.pokemon_id for poke in blacklist)):
                 odds = int(blacklist[[x[0] for x in blacklist].index(job.pokemon_id)][1])
                 if (randint(1, 100) <= odds):
-                    job.result = self.scout_info("Ignoring Pokemon: {} with odds of {}".format(job.pokemon_name, odds))
+                    job.result = self.log_info("Ignoring Pokemon: {} with odds of {}".format(job.pokemon_name, odds))
                     continue
 
             try:

--- a/pgscout/Scout.py
+++ b/pgscout/Scout.py
@@ -64,7 +64,7 @@ class Scout(POGOAccount):
             if (any(poke[0] == job.pokemon_id for poke in blacklist)):
                 odds = int(blacklist[[x[0] for x in blacklist].index(job.pokemon_id)][1])
                 if (randint(1, 100) <= odds):
-                    job.result = self.log_info("Ignoring Pokemon: {} with odds of {}".format(job.pokemon_name, odds))
+                    job.result = self.scout_error("Ignoring Pokemon: {} with odds of {}".format(job.pokemon_name, odds))
                     job.processed = True
                     continue
 

--- a/pgscout/Scout.py
+++ b/pgscout/Scout.py
@@ -10,7 +10,7 @@ from mrmime.utils import jitter_location
 from pgoapi.exceptions import AuthException, BannedAccountException
 from pgoapi.protos.pogoprotos.networking.responses.encounter_response_pb2 import *
 
-from pgscout.config import cfg_get, blacklist
+from pgscout.config import cfg_get, blacklist_get
 from pgscout.moveset_grades import get_moveset_grades
 from pgscout.stats import inc_for_pokemon
 from pgscout.utils import calc_pokemon_level, calc_iv
@@ -55,14 +55,16 @@ class Scout(POGOAccount):
         self.errors = 0
 
     def run(self):
+        blacklist = blacklist_get()
         self.log_info("Waiting for job...")
         while True:
             job = self.job_queue.get()
 
             #% chance of ignoring a pokemon, specified per individual pokemon in file
-            if (job.pokemon_id in blacklist):
-                if randint(1, 100) <= blacklist[[x[0] for x in blacklist].index(job.pokemon_id)][1]:
-                    job.result = self.scout_error("Ignoring Pokemon: {} with odds of {}").format(job.pokemon_name, args.blacklist[[x[0] for x in args.maybelist].index(pokemon_id)][1])
+            if (any(poke[0] == job.pokemon_id for poke in blacklist)):
+                odds = int(blacklist[[x[0] for x in blacklist].index(job.pokemon_id)][1])
+                if (randint(1, 100) <= odds):
+                    job.result = self.scout_info("Ignoring Pokemon: {} with odds of {}".format(job.pokemon_name, odds))
                     continue
 
             try:

--- a/pgscout/Scout.py
+++ b/pgscout/Scout.py
@@ -64,7 +64,7 @@ class Scout(POGOAccount):
             if (any(poke[0] == job.pokemon_id for poke in blacklist)):
                 odds = int(blacklist[[x[0] for x in blacklist].index(job.pokemon_id)][1])
                 if (randint(1, 100) <= odds):
-                    job.result = self.scout_error("Ignoring Pokemon: {} with odds of {}".format(job.pokemon_name, odds))
+                    job.result = self.scout_error("Ignoring {} (ignore rate {})".format(job.pokemon_name, odds))
                     job.processed = True
                     continue
 

--- a/pgscout/Scout.py
+++ b/pgscout/Scout.py
@@ -65,6 +65,7 @@ class Scout(POGOAccount):
                 odds = int(blacklist[[x[0] for x in blacklist].index(job.pokemon_id)][1])
                 if (randint(1, 100) <= odds):
                     job.result = self.log_info("Ignoring Pokemon: {} with odds of {}".format(job.pokemon_name, odds))
+                    job.processed = True
                     continue
 
             try:

--- a/pgscout/Scout.py
+++ b/pgscout/Scout.py
@@ -10,11 +10,10 @@ from mrmime.utils import jitter_location
 from pgoapi.exceptions import AuthException, BannedAccountException
 from pgoapi.protos.pogoprotos.networking.responses.encounter_response_pb2 import *
 
-from pgscout.config import cfg_get, blacklist_get
+from pgscout.config import cfg_get
 from pgscout.moveset_grades import get_moveset_grades
 from pgscout.stats import inc_for_pokemon
 from pgscout.utils import calc_pokemon_level, calc_iv
-from random import randint
 
 log = logging.getLogger(__name__)
 
@@ -55,18 +54,9 @@ class Scout(POGOAccount):
         self.errors = 0
 
     def run(self):
-        blacklist = blacklist_get()
         self.log_info("Waiting for job...")
         while True:
             job = self.job_queue.get()
-
-            #% chance of ignoring a pokemon, specified per individual pokemon in file
-            if (any(poke[0] == job.pokemon_id for poke in blacklist)):
-                odds = int(blacklist[[x[0] for x in blacklist].index(job.pokemon_id)][1])
-                if (randint(1, 100) <= odds):
-                    job.result = self.scout_error("Ignoring {} (ignore rate {})".format(job.pokemon_name, odds))
-                    job.processed = True
-                    continue
 
             try:
                 self.log_info(u"Scouting a {} at {}, {}".format(job.pokemon_name, job.lat, job.lng))

--- a/pgscout/Scout.py
+++ b/pgscout/Scout.py
@@ -10,10 +10,11 @@ from mrmime.utils import jitter_location
 from pgoapi.exceptions import AuthException, BannedAccountException
 from pgoapi.protos.pogoprotos.networking.responses.encounter_response_pb2 import *
 
-from pgscout.config import cfg_get
+from pgscout.config import cfg_get, blacklist
 from pgscout.moveset_grades import get_moveset_grades
 from pgscout.stats import inc_for_pokemon
 from pgscout.utils import calc_pokemon_level, calc_iv
+from random import randint
 
 log = logging.getLogger(__name__)
 
@@ -57,6 +58,13 @@ class Scout(POGOAccount):
         self.log_info("Waiting for job...")
         while True:
             job = self.job_queue.get()
+
+            #% chance of ignoring a pokemon, specified per individual pokemon in file
+            if (job.pokemon_id in blacklist):
+                if randint(1, 100) <= blacklist[[x[0] for x in blacklist].index(job.pokemon_id)][1]:
+                    job.result = self.scout_error("Ignoring Pokemon: {} with odds of {}").format(job.pokemon_name, args.blacklist[[x[0] for x in args.maybelist].index(pokemon_id)][1])
+                    continue
+
             try:
                 self.log_info(u"Scouting a {} at {}, {}".format(job.pokemon_name, job.lat, job.lng))
                 # Initialize API

--- a/pgscout/config.py
+++ b/pgscout/config.py
@@ -42,6 +42,11 @@ def parse_args():
     parser.add_argument('-pf', '--proxies-file',
                         help='Load proxy list from text file (one proxy per line).')
 
+    parser.add_argument('-bl', '--blacklist-file',
+                        help='List of pokemon IDs to ignore along with the ' +
+                        'percentage of the time they should be ignored, ' +
+                        'which is specified as integer from 0-100 in 2nd column')
+
     parser.add_argument('-l', '--level', type=int, default=30,
                         help='Minimum trainer level required. Lower levels will yield an error.')
 
@@ -109,6 +114,12 @@ def cfg_init():
     args.proxy_provider = CyclicResourceProvider()
     for proxy in args.proxies:
         args.proxy_provider.add_resource(proxy)
+        
+    # Create blacklist-file
+    args.blacklist = []
+    if args.blacklist_file:
+        with open(args.blacklist_file) as f:
+            args.blacklistlist = [tuple(map(int, l.split())) for l in f]
 
 
 def use_pgpool():

--- a/pgscout/config.py
+++ b/pgscout/config.py
@@ -19,6 +19,11 @@ def cfg_get(key, default=None):
     return getattr(args, key)
 
 
+def blacklist_get():
+    global blacklist
+    return blacklist
+
+
 def parse_args():
     global args
     defaultconfigfiles = []
@@ -91,6 +96,7 @@ def init_resoures_from_file(resource_file):
 
 
 def cfg_init():
+    global blacklist
     log.info("Loading PGScout configuration...")
 
     parse_args()
@@ -121,6 +127,7 @@ def cfg_init():
         log.info("Loading blacklist file {}".format(args.blacklist_file))
         with open(args.blacklist_file) as f:
             blacklist = [tuple(map(int, l.split())) for l in f]
+        log.info('Ignoring these pokemon %s', blacklist)
 
 
 def use_pgpool():

--- a/pgscout/config.py
+++ b/pgscout/config.py
@@ -125,8 +125,11 @@ def cfg_init():
     # Create blacklist-file
     if args.blacklist_file:
         log.info("Loading blacklist file {}".format(args.blacklist_file))
-        with open(args.blacklist_file) as f:
-            blacklist = [tuple(map(int, l.split())) for l in f]
+        for line in open(args.blacklist_file):
+            info = tuple(map(int, line.split(",")))
+            if (len(info) < 2):
+                info  = info + (100,)
+            blacklist.append(info)
         log.info('Ignoring these pokemon %s', blacklist)
 
 

--- a/pgscout/config.py
+++ b/pgscout/config.py
@@ -116,10 +116,11 @@ def cfg_init():
         args.proxy_provider.add_resource(proxy)
         
     # Create blacklist-file
-    args.blacklist = []
+    blacklist = []
     if args.blacklist_file:
+        log.info("Loading blacklist file {}".format(args.blacklist_file))
         with open(args.blacklist_file) as f:
-            args.blacklistlist = [tuple(map(int, l.split())) for l in f]
+            blacklist = [tuple(map(int, l.split())) for l in f]
 
 
 def use_pgpool():

--- a/pgscout/config.py
+++ b/pgscout/config.py
@@ -11,6 +11,7 @@ from pgscout.proxy import check_proxies
 log = logging.getLogger(__name__)
 
 args = None
+blacklist = []
 
 
 def cfg_get(key, default=None):
@@ -116,7 +117,6 @@ def cfg_init():
         args.proxy_provider.add_resource(proxy)
         
     # Create blacklist-file
-    blacklist = []
     if args.blacklist_file:
         log.info("Loading blacklist file {}".format(args.blacklist_file))
         with open(args.blacklist_file) as f:


### PR DESCRIPTION
Use -bl or -blacklist-file to specify a list of pokemon id's to blacklist along with an optional ignore rate for each (default 100)

The format of the file is one line per pokemon with one or two columns separated by a comma such as follows:  (extra whitespace is OK for formatting purposes and will be stripped out)
POKEMON_ID
POKEMON_ID, IGNORE_RATE

The IGNORE_RATE for a pokemon is a optional value from 0-100.  
- 100 means it is always ignored (DEFAULT)
- 1-99 means that is the % of time it will be ignored
- 0 means it is never ignored

I checked this functionality a few different ways:
- created a file with all pokemon at 100 odds
- created a file with random odds
- created a file with all pokemon at 0 odds
- ran without a file

I've been running for weeks without issue.  Blacklist messages are passed back to Rocketmap and they end up in the RM log for easy grepping.

![image](https://user-images.githubusercontent.com/15407947/32982274-90d9e170-cc47-11e7-86d4-4209b1ee3b3d.png)
![image](https://user-images.githubusercontent.com/15407947/32982288-c3281e62-cc47-11e7-8c67-87b6a1e5d466.png)
![image](https://user-images.githubusercontent.com/15407947/32982284-b80b7af6-cc47-11e7-9343-5662ab767668.png)

NOTE:
Rocketmap requires a change to add a 'force' attribute to the PGScout request to allow on-demand scanning of blacklisted pokemon