### PR TITLE
Fix incorrect logging display when initial_view set to scout or pokemon screen

### DIFF
--- a/pgscout/console.py
+++ b/pgscout/console.py
@@ -15,10 +15,11 @@ from pgscout.config import cfg_get
 from pgscout.stats import get_pokemon_stats
 from pgscout.utils import get_pokemon_name, rss_mem_size, app_state
 
+default_log_level = 0
 
 def input_processor(state):
     mainlog = logging.getLogger()
-    default_log_level = mainlog.getEffectiveLevel()
+    global default_log_level
 
     while True:
         # Wait for the user to press a key.
@@ -47,11 +48,17 @@ def input_processor(state):
 
 def print_status(scouts, initial_display, jobs):
     global status
+    global default_log_level
 
     state = {
         'page': 1,
         'display': initial_display
     }
+
+    default_log_level = logging.getLogger().getEffectiveLevel()
+    if initial_display != 'logs':
+        logging.getLogger().setLevel(logging.CRITICAL)
+    
     # Start another thread to get user input.
     t = Thread(target=input_processor,
                name='input_processor',


### PR DESCRIPTION
When initial view is set and the default is not 'logs' the log is errantly not turned off.  This fixes that.  There is also another change to capture the default_log_level just before this is done.  Otherwise there is a race condition and the log gets set to critical in the print-status routine before being captured in the input-processor routine.  Thus it is ALWAYS seen as critical and the logs can never be restarted after initial-view of scout or pokemon.